### PR TITLE
Support property-expansion for command

### DIFF
--- a/inputevent.lua
+++ b/inputevent.lua
@@ -179,6 +179,13 @@ function InputEvent:emit(event)
         return
     end
 
+    local expand = mp.command_native({'expand-text', cmd})
+    if #cmd:split(";") == #expand:split(";") then
+        cmd = mp.command_native({'expand-text', cmd})
+    else
+        mp.msg.warn("Unsafe property-expansion: " .. cmd)
+    end
+
     command(cmd)
 end
 


### PR DESCRIPTION
**Syntax:**
[property-expansion](https://mpv.io/manual/master/#property-expansion)

**Example:**

input.conf

set output TRC to be the same as input.
```ini
set target-trc ${video-params/gamma}
```

ternary operators like.
```ini
set target-trc ${?video-params/gamma==pq:hlg}${!video-params/gamma==pq:bt.1886}
```

evafast like speedup.
```ini
SPACE           cycle pause                                                                 #@click
SPACE           no-osd set speed 1; set pause no                                            #@press
SPACE           ignore                                                                      #@release
SPACE           no-osd add speed ${?speed==4.00:0}${!speed==4.00:0.1}; show-text ${speed}   #@repeat
```

**TODO:**
- [ ] MPV parse the input.conf on startup and shows an error.
![image](https://user-images.githubusercontent.com/50797982/202152829-d4d81a02-5ab5-4d64-ba2b-387f9762923c.png)

- [x] Injection via ";" in the string.
Split commands by ";" and compare the array length of raw_cmd and expanded. This is probably safe enough.
```sh
> filename="example; set unsafe true; play another.mp4"
> set title ${title}
> set title example; set unsafe true; play another.mp4
```