### PR TITLE
Several improvements for config

### DIFF
--- a/inputevent.lua
+++ b/inputevent.lua
@@ -7,7 +7,6 @@ local options = require("mp.options")
 local o = {
     configs = "input.conf",
 }
-options.read_options(o)
 
 local bind_map = {}
 
@@ -370,6 +369,15 @@ function bind_from_options_configs()
     end
 end
 
+function on_options_configs_update(list)
+    if(list.configs) then
+        for key, value in pairs(bind_map) do
+            unbind(key)
+        end
+        bind_from_options_configs()
+    end
+end
+
 mp.observe_property("input-doubleclick-time", "native", function(_, new_duration)
     for _, binding in pairs(bind_map) do
         binding:rebind({ duration = new_duration })
@@ -384,5 +392,7 @@ end)
 
 mp.register_script_message("bind", bind)
 mp.register_script_message("unbind", unbind)
+
+options.read_options(o, _, on_options_configs_update)
 
 bind_from_options_configs()


### PR DESCRIPTION
Key bindings in different files are override rather than merged.

close #22

mpv.conf

```ini
script-opts-add=inputevent-configs="input.conf,~~/test.conf,~~/test.json"
```

input.conf

```ini
SPACE               cycle pause         #@click
SPACE               set speed  2.0      #@press
SPACE               set speed  1.0      #@release
```

test.conf

```ini
SPACE               set speed  0.5      #@press
SPACE               set speed  1.0      #@release
```

test.json

```json
[
  {
    "key": "SPACE",
    "on": {
      "click": "show-text click",
      "double_click": "show-text double-click",
      "penta_click": "show-text penta-click",
      "press": "show-text pressed",
      "quatra_click": "show-text quatra-click",
      "release": "show-text released",
      "repeat": "show-text repeat",
      "triple_click": "show-text triple-click"
    }
  }
]

```

**Update configs in runtime**

mpv.conf

```ini
[fullscreen]
profile-cond=fullscreen
profile-restore=copy-equal
script-opts-add=inputevent-configs="input.conf,~~/test.json"
```
