### PR TITLE
Escape backslash in string arguments of the inverse command

### DIFF
--- a/inputevent.lua
+++ b/inputevent.lua
@@ -187,7 +187,7 @@ function command_invert(command)
             elseif type(value) == 'boolean' then
                 value = value and 'yes' or 'no'
             elseif type(value) == 'string' then
-                value = '"' .. value:replace('"', '\\"') .. '"'
+                value = '"' .. value:replace('\\', '\\\\'):replace('"', '\\"') .. '"'
             elseif type(value) == 'nil' then
                 use_del = true
             else


### PR DESCRIPTION
根据 https://mpv.io/manual/master/#flat-command-syntax 所说，input.conf 语法双引号内部的转义规则与JSON一致，之前漏掉了反斜杠