### PR TITLE
Simplify `debounce()` function

### DIFF
--- a/inputevent.lua
+++ b/inputevent.lua
@@ -98,19 +98,13 @@ function debounce(func, wait)
     wait = type(wait) == "number" and wait / 1000 or 0
 
     local timer = nil
-    local timer_end = function()
-        if timer then
-            timer:kill()
-            timer = nil
-        end
-        func()
-    end
 
     return function()
-        if timer then
-            timer:kill()
+        if not timer then
+            timer = mp.add_timeout(wait, func, true)
         end
-        timer = mp.add_timeout(wait, timer_end)
+        timer:kill()
+        timer:resume()
     end
 end
 


### PR DESCRIPTION
防抖函数每次执行时都创建一个新定时器没太必要，通过 [kill()](https://mpv.io/manual/master/#lua-scripting-kill()) + [resume()](https://mpv.io/manual/master/#lua-scripting-resume()) 可以使定时器恢复初始状态，这样的话同一个防抖函数可以复用一个定时器

定时器结束时调用 `kill()` 没太必要，[oneshot类型的定时器结束时会自动调用 kill()](https://github.com/mpv-player/mpv/blob/cdf77d927411d5a6efb00f69c911b8e16de5be73/player/lua/defaults.lua#L364-L369)， 那 `timer_end` 也可以简化掉了。
